### PR TITLE
Windows fixes

### DIFF
--- a/crates/bitang/Cargo.toml
+++ b/crates/bitang/Cargo.toml
@@ -19,7 +19,7 @@ eframe = { version = "0.31", features = ["wgpu"] }
 egui-wgpu = { version = "0.31" }
 egui_plot = "0.31"
 egui = "*"
-wgpu = { version = "*", features = ["spirv"] }
+wgpu = { version = "*", features = ["spirv", "dx12"] }
 wesl = "0.2"
 
 naga = { version = "*", features = ["spv-out", "wgsl-in"] }

--- a/crates/bitang/src/loader/shader_compiler.rs
+++ b/crates/bitang/src/loader/shader_compiler.rs
@@ -16,13 +16,15 @@ use spirq::ty::{DescriptorType, SpirvType, Type, VectorType};
 use spirq::var::Variable;
 use spirq::ReflectConfig;
 use tracing::{debug, error, info, instrument, trace, warn};
-use wesl::{Feature, Wesl};
+use wesl::{Feature, HashMangler, ModulePath, Wesl};
 use wgpu::{ShaderModule, ShaderModuleDescriptor};
 
 use crate::engine::{GlobalType, GlobalUniformMapping, GpuContext, ShaderKind};
 use crate::loader::resource_path::ResourcePath;
 
 const GLOBAL_UNIFORM_PREFIX: &str = "g_";
+
+struct WindowsPathSafeMangler {}
 
 pub struct ShaderCompilation {
     pub shader_artifact: ShaderArtifact,
@@ -46,6 +48,7 @@ impl ShaderCompilation {
                     .to_str()
                     .with_context(|| format!("Invalid root path '{:?}'", path.root_path))?,
             );
+            wesl.set_custom_mangler(HashMangler::default());
             let mut parent_module = path
                 .subdirectory
                 .to_str()

--- a/crates/bitang/src/tool/runners/window_runner.rs
+++ b/crates/bitang/src/tool/runners/window_runner.rs
@@ -8,6 +8,8 @@ use eframe::egui;
 use egui::ViewportBuilder;
 use egui_wgpu::{WgpuSetup, WgpuSetupCreateNew};
 use tracing::{debug, error, info};
+#[cfg(windows)]
+use wgpu::Backends;
 
 use crate::engine::{
     BitangImage, FrameContext, GpuContext, PixelFormat, Size2D, SwapchainImage, Viewport,

--- a/crates/egui-wgpu-patch/Cargo.toml
+++ b/crates/egui-wgpu-patch/Cargo.toml
@@ -59,7 +59,7 @@ profiling.workspace = true
 thiserror.workspace = true
 type-map.workspace = true
 web-time.workspace = true
-wgpu = { workspace = true, features = ["wgsl"] }
+wgpu = { workspace = true, features = ["wgsl", "dx12"] }
 
 # Optional dependencies:
 


### PR DESCRIPTION
Uses WESL hashmangler, because the default one crashes on Windows :(
Temporary patch for #269, need to send PR to WESL. 